### PR TITLE
Modularize AWS services using mock-able interfaces.

### DIFF
--- a/backend/database.go
+++ b/backend/database.go
@@ -3,56 +3,101 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/guregu/dynamo"
 )
 
-type ID = uint64
+type UserID = uint64
+type GroupID = uint64
 
-type Database struct {
+type Database interface {
+	CreateUser(User) error
+	ReadUser(UserID) (*User, error)
+	DeleteUser(UserID) error
+	CreateGroup(Group) error
+	ReadGroup(GroupID) (*Group, error)
+	DeleteGroup(GroupID) error
+}
+
+type DynamoDB struct {
 	groups dynamo.Table
 	users  dynamo.Table
 }
 
-func initializeNewDatabase(db *dynamo.DB) *Database {
-	return &Database{
+func NewDynamoDB(sess *session.Session) Database {
+	// TODO: Hard-coded region.
+	db := dynamo.New(sess, &aws.Config{Region: aws.String("us-east-1")})
+	return &DynamoDB{
 		groups: db.Table("Groups"),
 		users:  db.Table("Users"),
 	}
 }
 
-func (database *Database) InsertNewUser(userInfo User) error {
-	err := database.users.Put(userInfo).Run()
+func (dynamoDB *DynamoDB) CreateUser(userInfo User) error {
+	err := dynamoDB.users.Put(userInfo).Run()
 	return err
 }
 
-func (database *Database) InsertNewGroup(groupInfo Group) error {
-	err := database.groups.Put(groupInfo).Run()
+func (dynamoDB *DynamoDB) ReadUser(userId UserID) (*User, error) {
+	// TODO: unimplemented.
+	return nil, nil
+}
+
+func (dynamoDB *DynamoDB) DeleteUser(userID UserID) error {
+	err := dynamoDB.users.Delete("UserID", userID).Run()
 	return err
 }
 
-func (database *Database) InsertNewSchedule(userID ID, scheduleInfo Schedule) error {
-	err := database.users.Update("UserID", userID).Append("Schedules", scheduleInfo).Run()
+func (dynamoDB *DynamoDB) CreateGroup(groupInfo Group) error {
+	err := dynamoDB.groups.Put(groupInfo).Run()
 	return err
 }
 
-func (database *Database) UpdateGroupInfo(groupID ID, newInfo Group) error {
-	err := database.groups.Update("GroupID", groupID).Set("Group", newInfo).Run()
+func (dynamoDB *DynamoDB) ReadGroup(groupID GroupID) (*Group, error) {
+	// TODO: unimplemented.
+	return nil, nil
+}
+
+func (dynamoDB *DynamoDB) DeleteGroup(groupID GroupID) error {
+	err := dynamoDB.groups.Delete("GroupID", groupID).Run()
 	return err
 }
 
-func (database *Database) UpdateUserInfo(userID ID, newInfo User) error {
-	err := database.users.Update("UserID", userID).Set("User", newInfo).Run()
+func (dynamoDB *DynamoDB) InsertNewUser(userInfo User) error {
+	err := dynamoDB.users.Put(userInfo).Run()
 	return err
 }
 
-func (database *Database) deleteUserFromGroup(userInfo User, groupID ID) error {
+func (dynamoDB *DynamoDB) InsertNewGroup(groupInfo Group) error {
+	err := dynamoDB.groups.Put(groupInfo).Run()
+	return err
+}
+
+func (dynamoDB *DynamoDB) InsertNewSchedule(userID UserID, scheduleInfo Schedule) error {
+	err := dynamoDB.users.Update("UserID", userID).Append("Schedules", scheduleInfo).Run()
+	return err
+}
+
+func (dynamoDB *DynamoDB) UpdateGroupInfo(groupID GroupID, newInfo Group) error {
+	err := dynamoDB.groups.Update("GroupID", groupID).Set("Group", newInfo).Run()
+	return err
+}
+
+func (dynamoDB *DynamoDB) UpdateUserInfo(userID UserID, newInfo User) error {
+	err := dynamoDB.users.Update("UserID", userID).Set("User", newInfo).Run()
+	return err
+}
+
+func (dynamoDB *DynamoDB) deleteUserFromGroup(userInfo User, groupID GroupID) error {
 	//Check if group exists, check if user exists
-	err := database.groups.Update("GroupID", groupID).DeleteFromSet("Users", userInfo).Run()
+	err := dynamoDB.groups.Update("GroupID", groupID).DeleteFromSet("Users", userInfo).Run()
 	return err
 }
 
-func (database *Database) deleteGroup(groupInfo Group) error {
-	err := database.groups.Delete("GroupID", groupInfo.GroupID).Run()
+func (dynamoDB *DynamoDB) deleteGroup(groupInfo Group) error {
+	err := dynamoDB.groups.Delete("GroupID", groupInfo.GroupID).Run()
 	return err
 }
 

--- a/backend/database.go
+++ b/backend/database.go
@@ -65,16 +65,6 @@ func (dynamoDB *DynamoDB) DeleteGroup(groupID GroupID) error {
 	return err
 }
 
-func (dynamoDB *DynamoDB) InsertNewUser(userInfo User) error {
-	err := dynamoDB.users.Put(userInfo).Run()
-	return err
-}
-
-func (dynamoDB *DynamoDB) InsertNewGroup(groupInfo Group) error {
-	err := dynamoDB.groups.Put(groupInfo).Run()
-	return err
-}
-
 func (dynamoDB *DynamoDB) InsertNewSchedule(userID UserID, scheduleInfo Schedule) error {
 	err := dynamoDB.users.Update("UserID", userID).Append("Schedules", scheduleInfo).Run()
 	return err
@@ -93,11 +83,6 @@ func (dynamoDB *DynamoDB) UpdateUserInfo(userID UserID, newInfo User) error {
 func (dynamoDB *DynamoDB) deleteUserFromGroup(userInfo User, groupID GroupID) error {
 	//Check if group exists, check if user exists
 	err := dynamoDB.groups.Update("GroupID", groupID).DeleteFromSet("Users", userInfo).Run()
-	return err
-}
-
-func (dynamoDB *DynamoDB) deleteGroup(groupInfo Group) error {
-	err := dynamoDB.groups.Delete("GroupID", groupInfo.GroupID).Run()
 	return err
 }
 

--- a/backend/dbschema.go
+++ b/backend/dbschema.go
@@ -5,54 +5,54 @@ import (
 )
 
 type Group struct {
-	GroupID 	int       				 `dynamo:"ID,hash"`	  // Hash key, a.k.a. partition key
+	GroupID GroupID `dynamo:"ID,hash"` // Hash key, a.k.a. partition key
 	//Time   time.Time // Range key, a.k.a. sort key
 
-	Name   		string
+	Name string
 	//Count int                 		 `dynamo:",omitempty"` // Omits if zero value
-	Polls  	    []Poll            		 `dynamo:",set"`
-	Users  		map[string]User			 `dynamo:",set"`
-	Messages 	map[string]Message 		 `dynamo:",set"`
+	Polls    []Poll             `dynamo:",set"`
+	Users    map[string]User    `dynamo:",set"`
+	Messages map[string]Message `dynamo:",set"`
 }
 
 type User struct {
-	UserID       int 					`dynamo:"ID,hash"` // Hash key, a.k.a. partition key
+	UserID       UserID `dynamo:"ID,hash"` // Hash key, a.k.a. partition key
 	Username     string
-	GroupIDs     []string 				`dynamo:",set"`
+	GroupIDs     []string `dynamo:",set"`
 	WebSocketIDs []string
-	Schedules    map[string]Schedule 	`dynamo:",set"`
+	Schedules    map[string]Schedule `dynamo:",set"`
 }
 
 type Poll struct {
-	PollID     int                   	`dynamo:"ID,hash"` // Hash key, a.k.a. partition key
-	Timestamp  time.Time             	`dynamo:",range"`  // Range key, a.k.a. sort key
-	PollResult map[string]PollResult 	`dynamo:",set"`
+	PollID     int                   `dynamo:"ID,hash"` // Hash key, a.k.a. partition key
+	Timestamp  time.Time             `dynamo:",range"`  // Range key, a.k.a. sort key
+	PollResult map[string]PollResult `dynamo:",set"`
 	DoneFlag   bool
 }
 
 type Message struct {
-	MessageId 	int  				`dynamo:"ID,hash"` //Hash key
-	Timestamp 	time.Time			`dynamo:",range"`
-	Content   	string			    `dynamo:"Message"`
-	UserID	  	int
+	MessageId int       `dynamo:"ID,hash"` //Hash key
+	Timestamp time.Time `dynamo:",range"`
+	Content   string    `dynamo:"Message"`
+	UserID    int
 }
 
 type PollResult struct {
-	pollResultID int 				`dynamo:"ID,hash"` //Hash key
+	pollResultID int `dynamo:"ID,hash"` //Hash key
 	Option       string
-	userIDVoted  []int 				`dynamo:",set"`
+	userIDVoted  []int `dynamo:",set"`
 }
 
 type Schedule struct {
-	ScheduleID int 					`dynamo:"ID,hash"`
+	ScheduleID int `dynamo:"ID,hash"`
 	Year       int
 	Month      int
 	Day        int
-	Tasks      map[string]Task 		`dynamo:",set"`
+	Tasks      map[string]Task `dynamo:",set"`
 }
 
 type Task struct {
-	TaskID    int 					`dynamo:"ID,hash"`
+	TaskID    int `dynamo:"ID,hash"`
 	TaskName  string
 	StartTime string //HHMM format string
 	EndTime   string //HHMM format string

--- a/backend/main.go
+++ b/backend/main.go
@@ -10,19 +10,13 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/apigatewaymanagementapi"
 	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
-	"github.com/guregu/dynamo"
 )
 
 // Take an authenticated AWS session and create a handler for HTTP
 // and WebSocket events from AWS API Gateway.
-func NewHandler(sess *session.Session) func(context context.Context, event json.RawMessage) (events.APIGatewayProxyResponse, error) {
-	var db = dynamo.New(sess, &aws.Config{Region: aws.String("us-west-2")})
-	_ = initializeNewDatabase(db)
-	_ = apigatewaymanagementapi.New(sess)
+func NewHandler(database Database, _notification Notification) func(context context.Context, event json.RawMessage) (events.APIGatewayProxyResponse, error) {
 
 	mux := http.NewServeMux()
 
@@ -58,6 +52,9 @@ func main() {
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 
+	database := NewDynamoDB(sess)
+	notification := NewApiGateway(sess)
+
 	// Start handling events.
-	lambda.Start(NewHandler(sess))
+	lambda.Start(NewHandler(database, notification))
 }

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,16 +33,65 @@ func TestHandler(t *testing.T) {
 		},
 	}
 
-	// Need deprecated API to avoid missing credential error.
-	sess := session.New()
-	context := context.Background()
 	for _, test := range tests {
+		database := &MockDatabase{}
+		notification := &MockNotification{}
+		context := context.Background()
 		json, err := json.Marshal(test.request)
 		if err != nil {
 			panic(err)
 		}
-		response, err := NewHandler(sess)(context, json)
+		response, err := NewHandler(database, notification)(context, json)
 		assert.IsType(t, test.err, err)
 		assert.Equal(t, string(test.response), response.Body)
 	}
+}
+
+type MockDatabase struct {
+	users  map[UserID]User
+	groups map[GroupID]Group
+}
+
+func (mockDatabase *MockDatabase) CreateUser(user User) error {
+	mockDatabase.users[user.UserID] = user
+	return nil
+}
+
+func (mockDatabase *MockDatabase) ReadUser(userID UserID) (*User, error) {
+	user, ok := mockDatabase.users[userID]
+	if ok {
+		return &user, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (mockDatabase *MockDatabase) DeleteUser(userID UserID) error {
+	delete(mockDatabase.users, userID)
+	return nil
+}
+
+func (mockDatabase *MockDatabase) CreateGroup(group Group) error {
+	mockDatabase.groups[group.GroupID] = group
+	return nil
+}
+
+func (mockDatabase *MockDatabase) ReadGroup(groupId GroupID) (*Group, error) {
+	group, ok := mockDatabase.groups[groupId]
+	if ok {
+		return &group, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (mockDatabase *MockDatabase) DeleteGroup(groupID GroupID) error {
+	delete(mockDatabase.groups, groupID)
+	return nil
+}
+
+type MockNotification struct{}
+
+func (mockNotification *MockNotification) Notify(connectionID ConnectionID, data any) error {
+	return fmt.Errorf("mock notification")
 }

--- a/backend/notification.go
+++ b/backend/notification.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigatewaymanagementapi"
+)
+
+type ConnectionID = string
+
+type Notification interface {
+	Notify(connectionID ConnectionID, data any) error
+}
+
+type APIGateway struct {
+	managementAPI *apigatewaymanagementapi.ApiGatewayManagementApi
+}
+
+func NewApiGateway(sess *session.Session) *APIGateway {
+	managementAPI := apigatewaymanagementapi.New(sess)
+	return &APIGateway{managementAPI}
+}
+
+func (apiGateway *APIGateway) Notify(connectionID ConnectionID, data any) error {
+	json, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("could not marshal notification to JSON: %s", err)
+	}
+	_, err = apiGateway.managementAPI.PostToConnection(&apigatewaymanagementapi.PostToConnectionInput{
+		ConnectionId: &connectionID,
+		Data:         json,
+	})
+	if err != nil {
+		return fmt.Errorf("could not notify: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Thank you for submitting this pull request!

## Description

- Create a `Database` interface implemented by `DynamoDB`
- Create a `Notification` interface implemented by `APIGateway`
- Mock those interfaces for testing (instead of creating a fake AWS session)
- Revert using `ID` for all ids (for code clarity and, in the future, using different types)
- Format code that wasn't formatted before to make the CI pass

## Testing strategy

CI

## Related issues

Followup to #1 

## Unresolved questions or future work

- Future work for @davengt is to add remaining methods to the interface
- How best to mock notifications?
- Need to precisely document the semantics of each interface method so implementations can conform