### PR TITLE
Create S3 and Route53 Terraform configurations

### DIFF
--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,6 +1,17 @@
-/*
-TODO: add the following resources
+resource "aws_route53_zone" "backend" {
+  name = var.domain
+}
 
-aws_route53_zone
-aws_route53_record (x2)
+// TODO: Uncomment when Cloudfront is added
+/*
+resource "aws_route53_record" "cloudfront" {
+  alias {
+    evaluate_target_health = false
+    name                   = aws_cloudfront_distribution.backend.domain_name
+    zone_id                = aws_cloudfront_distribution.backend.hosted_zone_id
+  }
+  name    = aws_route53_zone.backend.name
+  type    = "A"
+  zone_id = aws_route53_zone.backend.zone_id
+}
 */

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,9 +1,76 @@
-/*
-TODO: add the following resources.
-aws_s3_bucket
-aws_s3_bucket_acl
-aws_s3_bucket_cors_configuration
-aws_s3_bucket_website_configuration
-aws_s3_bucket_public_access_block
-aws_s3_object (for_each frontend file)
-*/
+resource "aws_s3_bucket" "frontend" {
+  bucket = "lemmeknow-frontend"
+}
+
+resource "aws_s3_bucket_ownership_controls" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "frontend" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.frontend,
+    aws_s3_bucket_public_access_block.frontend,
+  ]
+
+  bucket = aws_s3_bucket.frontend.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_cors_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+    allowed_headers = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "frontend" {
+  statement {
+    sid       = "public"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  policy = data.aws_iam_policy_document.frontend.json
+}
+
+resource "aws_s3_object" "frontend" {
+  bucket        = aws_s3_bucket.frontend.bucket
+  cache_control = "no-cache"
+  content_type = {
+    "html" = "text/html",
+    "xml"  = "application/xml",
+    "txt"  = "text/plain",
+    "js"   = "application/javascript",
+    "css"  = "text/css",
+    "json" = "application/json",
+    "ico"  = "image/x-icon",
+    "png"  = "image/png",
+  }[split(".", each.value)[length(split(".", each.value)) - 1]]
+  etag     = filemd5("../frontend/build/${each.value}")
+  for_each = fileset("../frontend/build", "**/*.*")
+  key      = each.value
+  source   = "../frontend/build/${each.value}"
+}

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -1,3 +1,8 @@
+variable "domain" {
+  default = "lemmeknow.com"
+  type    = string
+}
+
 variable "region" {
   default = "us-east-1"
   type    = string


### PR DESCRIPTION
Thank you for submitting this pull request!

## Description

- Create S3 configuration to host frontend
- Create Route53 configuration for a DNS hosted zone (domain name)

## Testing strategy

N/A

## Related issues

N/A

## Unresolved questions or future work

- Finding an available domain name
- Configuring frontend for static site export (adapter static)
- ACM will need a Route53 record to verify it's certificate