### PR TITLE
Make backend send empty lists instead of null.

### DIFF
--- a/backend/group.go
+++ b/backend/group.go
@@ -193,7 +193,7 @@ func RestSpecificGroupAPI(router *mux.Router, database Database, notification No
 				for _, option := range group.Poll.Options {
 					response.Poll.Options = append(response.Poll.Options, GetGroupResponsePollOption{
 						Name:  censor(option.Name),
-						Votes: option.Votes,
+						Votes: append([]UserID{}, option.Votes...),
 					})
 				}
 			}
@@ -205,7 +205,7 @@ func RestSpecificGroupAPI(router *mux.Router, database Database, notification No
 					Date:       activity.Date,
 					Start:      activity.Start,
 					End:        activity.End,
-					Confirmed:  activity.Confirmed,
+					Confirmed:  append([]UserID{}, activity.Confirmed...),
 				})
 			}
 

--- a/backend/user.go
+++ b/backend/user.go
@@ -97,7 +97,7 @@ func RestUserAPI(router *mux.Router, database Database, notification Notificatio
 			WriteJSON(w, GetUserResponse{
 				UserID: user.UserID,
 				Name:   user.Name,
-				Groups: user.Groups,
+				Groups: append([]GroupID{}, user.Groups...),
 				Status: user.Status,
 			})
 		case http.MethodPatch:


### PR DESCRIPTION
Thank you for submitting this pull request!

## Description

Title (for the following fields):
- poll votes
- user groups
- activity confirmations

Empty lists are easier to work with in the frontend, and satisfy the specification better.

## Testing strategy

CI

## Related issues

N/A

## Unresolved questions or future work

N/A